### PR TITLE
Fix Shiki setup browser compatibility

### DIFF
--- a/setup/shiki.ts
+++ b/setup/shiki.ts
@@ -1,15 +1,8 @@
 /* ./setup/shiki.ts */
 import { defineShikiSetup } from "@slidev/types";
-import fs from "fs";
-import path from "path";
+import theme from "../public/theme/theunnamed-dark-theme.json";
 
 export default defineShikiSetup(() => {
-  const filePath = path.resolve(
-    __dirname,
-    `../public/theme/theunnamed-dark-theme.json`
-  );
-  const contents = fs.readFileSync(filePath, "utf-8");
-  const theme = JSON.parse(contents);
   return {
     theme,
   };


### PR DESCRIPTION
## Summary

This updates the Shiki setup to import the theme JSON statically instead of reading it at runtime with Node-only APIs.

## Why

The current setup imports `fs` and `path`, then calls `path.resolve` and `fs.readFileSync`. That works in Node, but the Slidev web editor also loads the Shiki setup in the browser client. In that context, `path.resolve` is unavailable and the editor panel can fail to render.

## Change

- Remove `fs` and `path` from `setup/shiki.ts`
- Import `theunnamed-dark-theme.json` directly
- Return the same theme object from `defineShikiSetup`

## Verification

- Reproduced locally with Slidev web editor: blank editor panel and browser error about `path.resolve`
- Applied this change locally in a consuming deck
- Restarted Slidev with Vite cache invalidation
- Confirmed the web editor displays Markdown content again
- Ran `npm run build` in this theme repo successfully

Fixes #12